### PR TITLE
Implement WritableStream support for file and stop squelching errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ function separate(src, file, root, url) {
   return { json: json, src: newSrc + '\n' + comment }
 }
 
-var go = module.exports = 
+var go = module.exports =
 
 /**
  * Transforms the incoming stream of code by removing the inlined source map and writing it to an external map file.
@@ -31,7 +31,7 @@ var go = module.exports =
  * #### Events (other than all stream events like `error`)
  *
  *  - `missing-map` emitted if no map was found in the stream (the src still is piped through in this case, but no map file is written)
- * 
+ *
  * @name exorcist
  * @function
  * @param {String} file full path to the map file to which to write the extracted source map
@@ -53,7 +53,7 @@ function exorcist(file, url, root) {
           + 'Therefore it was piped through as is and no external map file generated.'
       );
       self.push(src);
-      return cb(); 
+      return cb();
     }
     self.push(separated.src);
     fs.writeFile(file, separated.json, 'utf8', cb)

--- a/index.js
+++ b/index.js
@@ -84,7 +84,12 @@ function exorcist(file, url, root) {
       });
     } else if ( typeof file === 'string' ) {
       // If it's a string, consider it a filename and then write to the file
-      fs.writeFile(file, separated.json, 'utf8', cb);
+      fs.writeFile(file, separated.json, 'utf8', function(err) {
+        if ( err ) {
+          self.emit('error', err);
+        }
+        cb();
+      });
     } else {
       self.emit('error', new Error('The file given to exorcist was an unknown type.'));
       cb();

--- a/test/exorcist.js
+++ b/test/exorcist.js
@@ -4,6 +4,7 @@
 var test     = require('tap').test
 var fs       = require('fs');
 var through  = require('through2')
+var stream   = require('stream')
 var exorcist = require('../')
 
 var fixtures = __dirname + '/fixtures';
@@ -18,6 +19,61 @@ test('\nwhen piping a bundle generated with browserify through exorcist without 
   var data = ''
   fs.createReadStream(fixtures + '/bundle.js', 'utf8')
     .pipe(exorcist(mapfile))
+    .pipe(through(onread, onflush));
+
+    function onread(d, _, cb) { data += d; cb(); }
+
+    function onflush(cb) {
+      var lines = data.split('\n')
+      t.equal(lines.length, 27, 'pipes entire bundle including prelude, sources and source map url')
+      t.equal(lines.pop(), '//# sourceMappingURL=bundle.js.map', 'last line as source map url pointing to .js.map file')
+
+      var map = JSON.parse(fs.readFileSync(mapfile, 'utf8'));
+      t.equal(map.file, 'generated.js', 'leaves file name unchanged')
+      t.equal(map.sources.length, 4, 'maps 4 source files')
+      t.equal(map.sourcesContent.length, 4, 'includes 4 source contents')
+      t.equal(map.mappings.length, 106, 'maintains mappings')
+      t.equal(map.sourceRoot, '', 'leaves source root an empty string')
+
+      cb();
+      t.end()
+    }
+})
+
+test('\nwhen piping a bundle generated with browserify through exorcist using a fs write stream as output', function (t) {
+  setup();
+  var data = ''
+  var ws = fs.createWriteStream(mapfile, {encoding: 'utf8'})
+  fs.createReadStream(fixtures + '/bundle.js', 'utf8')
+    .pipe(exorcist(ws, 'bundle.js.map'))
+    .pipe(through(onread, onflush));
+
+    function onread(d, _, cb) { data += d; cb(); }
+
+    function onflush(cb) {
+      var lines = data.split('\n')
+      t.equal(lines.length, 27, 'pipes entire bundle including prelude, sources and source map url')
+      t.equal(lines.pop(), '//# sourceMappingURL=bundle.js.map', 'last line as source map url pointing to .js.map file')
+
+      var map = JSON.parse(fs.readFileSync(mapfile, 'utf8'));
+      t.equal(map.file, 'generated.js', 'leaves file name unchanged')
+      t.equal(map.sources.length, 4, 'maps 4 source files')
+      t.equal(map.sourcesContent.length, 4, 'includes 4 source contents')
+      t.equal(map.mappings.length, 106, 'maintains mappings')
+      t.equal(map.sourceRoot, '', 'leaves source root an empty string')
+
+      cb();
+      t.end()
+    }
+})
+
+test('\nwhen piping a bundle generated with browserify through exorcist using a non-fs writable stream as output', function (t) {
+  setup();
+  var data = ''
+  var ws = new stream.PassThrough()
+  ws.pipe(fs.createWriteStream(mapfile, {encoding: 'utf8'}))
+  fs.createReadStream(fixtures + '/bundle.js', 'utf8')
+    .pipe(exorcist(ws, 'bundle.js.map'))
     .pipe(through(onread, onflush));
 
     function onread(d, _, cb) { data += d; cb(); }

--- a/test/exorcist.js
+++ b/test/exorcist.js
@@ -29,8 +29,8 @@ test('\nwhen piping a bundle generated with browserify through exorcist without 
 
       var map = JSON.parse(fs.readFileSync(mapfile, 'utf8'));
       t.equal(map.file, 'generated.js', 'leaves file name unchanged')
-      t.equal(map.sources.length, 4, 'maps 4 source files') 
-      t.equal(map.sourcesContent.length, 4, 'includes 4 source contents') 
+      t.equal(map.sources.length, 4, 'maps 4 source files')
+      t.equal(map.sourcesContent.length, 4, 'includes 4 source contents')
       t.equal(map.mappings.length, 106, 'maintains mappings')
       t.equal(map.sourceRoot, '', 'leaves source root an empty string')
 
@@ -55,8 +55,8 @@ test('\nwhen piping a bundle generated with browserify through exorcist and adju
 
       var map = JSON.parse(fs.readFileSync(mapfile, 'utf8'));
       t.equal(map.file, 'generated.js', 'leaves file name unchanged')
-      t.equal(map.sources.length, 4, 'maps 4 source files') 
-      t.equal(map.sourcesContent.length, 4, 'includes 4 source contents') 
+      t.equal(map.sources.length, 4, 'maps 4 source files')
+      t.equal(map.sourcesContent.length, 4, 'includes 4 source contents')
       t.equal(map.mappings.length, 106, 'maintains mappings')
       t.equal(map.sourceRoot, '', 'leaves source root an empty string')
 
@@ -81,8 +81,8 @@ test('\nwhen piping a bundle generated with browserify through exorcist and adju
 
       var map = JSON.parse(fs.readFileSync(mapfile, 'utf8'));
       t.equal(map.file, 'generated.js', 'leaves file name unchanged')
-      t.equal(map.sources.length, 4, 'maps 4 source files') 
-      t.equal(map.sourcesContent.length, 4, 'includes 4 source contents') 
+      t.equal(map.sources.length, 4, 'maps 4 source files')
+      t.equal(map.sourcesContent.length, 4, 'includes 4 source contents')
       t.equal(map.mappings.length, 106, 'maintains mappings')
       t.equal(map.sourceRoot, '/hello/world.map.js', 'adapts source root')
 

--- a/test/fixtures/bundle.js
+++ b/test/fixtures/bundle.js
@@ -2,7 +2,7 @@
 'use strict';
 
 var go = module.exports = function () {
-  return 'hey, I am bar';    
+  return 'hey, I am bar';
 };
 
 },{}],2:[function(require,module,exports){
@@ -11,7 +11,7 @@ var go = module.exports = function () {
 var bar = require('./bar');
 
 var go = module.exports = function () {
-  console.log(bar());  
+  console.log(bar());
 };
 
 },{"./bar":1}],3:[function(require,module,exports){

--- a/test/fixtures/bundle.nomap.js
+++ b/test/fixtures/bundle.nomap.js
@@ -2,7 +2,7 @@
 'use strict';
 
 var go = module.exports = function () {
-  return 'hey, I am bar';    
+  return 'hey, I am bar';
 };
 
 },{}],2:[function(require,module,exports){
@@ -11,7 +11,7 @@ var go = module.exports = function () {
 var bar = require('./bar');
 
 var go = module.exports = function () {
-  console.log(bar());  
+  console.log(bar());
 };
 
 },{"./bar":1}],3:[function(require,module,exports){


### PR DESCRIPTION
Besides cleaning up some trailing white-space I've implemented two things.

Firstly, I've implemented support for passing a writable stream as file instead of a string path of a file to write to.
  - If a writable stream is used, url becomes non-optional.
  - exorcist ends whatever writable stream is passed to it, it is not expected to write to one that expects to be able to write more after (I can't see any reason for that anyways)
  - Writable streams are tested by duck-type to support 3rd party/old/new streams and non-fs.WriteStream writable streams
    - For example, a personal use case I have is passing a map to an interface that expects a readable stream which it pipes to a write stream or a file of its own choosing. So I pass exorcist a stream.PassThrough which I then pass to the interface.

Secondly, I've changed writeFile so that if there is an error during writing to the file it is emitted into the stream instead of being squelched.