### PR TITLE
Enabling deep non-existing path for extracted source map as well as CSS maps support

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,8 @@
 var convert = require('convert-source-map')
   , path = require('path')
   , fs = require('fs')
-  , through = require('through2');
+  , through = require('through2')
+  , mkdirp = require('mkdirp');
 
 function separate(src, file, root, url) {
   var inlined = convert.fromSource(src);

--- a/index.js
+++ b/index.js
@@ -17,8 +17,11 @@ function separate(src, file, root, url) {
 
   url = url || path.basename(file);
 
+  var type = url.split('.').slice(-2, -1)[0];
   var newSrc = convert.removeComments(src);
-  var comment = '//# sourceMappingURL=' + url;
+  var comment = type === 'css' ? '/*' : '//';
+  comment += '# sourceMappingURL=' + url;
+  comment += type === 'css' ? ' */' : '';
 
   return { json: json, src: newSrc + '\n' + comment }
 }

--- a/index.js
+++ b/index.js
@@ -57,7 +57,11 @@ function exorcist(file, url, root) {
       return cb(); 
     }
     self.push(separated.src);
-    fs.writeFile(file, separated.json, 'utf8', cb)
+    // Ensure path on fs for source map path string
+    mkdirp(path.dirname(file), function (err) {
+      if (err) return cb(err);
+      fs.writeFile(file, separated.json, 'utf8', cb);
+    });
   }
 
   return through(ondata, onend);

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   },
   "devDependencies": {
     "tap": "~0.4.3",
-    "browserify": "~3.20.0"
+    "browserify": "~3.20.0",
+    "mkdirp": "^0.5.0"
   },
   "keywords": [
     "source-map",

--- a/test/exorcist.js
+++ b/test/exorcist.js
@@ -9,12 +9,11 @@ var exorcist = require('../')
 var fixtures = __dirname + '/fixtures';
 var mapfile = fixtures + '/bundle.js.map';
 
-function setup() {
+function cleanup() {
   if (fs.existsSync(mapfile)) fs.unlinkSync(mapfile);
 }
 
 test('\nwhen piping a bundle generated with browserify through exorcist without adjusting properties', function (t) {
-  setup();
   var data = ''
   fs.createReadStream(fixtures + '/bundle.js', 'utf8')
     .pipe(exorcist(mapfile))
@@ -35,12 +34,12 @@ test('\nwhen piping a bundle generated with browserify through exorcist without 
       t.equal(map.sourceRoot, '', 'leaves source root an empty string')
 
       cb();
-      t.end()
+      t.end();
+      cleanup();
     }
 })
 
 test('\nwhen piping a bundle generated with browserify through exorcist and adjusting url', function (t) {
-  setup();
   var data = ''
   fs.createReadStream(fixtures + '/bundle.js', 'utf8')
     .pipe(exorcist(mapfile, 'http://my.awseome.site/bundle.js.map'))
@@ -61,12 +60,12 @@ test('\nwhen piping a bundle generated with browserify through exorcist and adju
       t.equal(map.sourceRoot, '', 'leaves source root an empty string')
 
       cb();
-      t.end()
+      t.end();
+      cleanup();
     }
 })
 
 test('\nwhen piping a bundle generated with browserify through exorcist and adjusting root and url', function (t) {
-  setup();
   var data = ''
   fs.createReadStream(fixtures + '/bundle.js', 'utf8')
     .pipe(exorcist(mapfile, 'http://my.awseome.site/bundle.js.map', '/hello/world.map.js'))
@@ -87,12 +86,12 @@ test('\nwhen piping a bundle generated with browserify through exorcist and adju
       t.equal(map.sourceRoot, '/hello/world.map.js', 'adapts source root')
 
       cb();
-      t.end()
+      t.end();
+      cleanup();
     }
 })
 
 test('\nwhen piping a bundle generated with browserify thats missing a map through exorcist' , function (t) {
-  setup();
   var data = ''
   var missingMapEmitted = false;
   fs.createReadStream(fixtures + '/bundle.nomap.js', 'utf8')

--- a/test/exorcist.js
+++ b/test/exorcist.js
@@ -8,9 +8,15 @@ var exorcist = require('../')
 
 var fixtures = __dirname + '/fixtures';
 var mapfile = fixtures + '/bundle.js.map';
+var deepMapfile = fixtures + '/1/2/bundle.js.map';
 
 function cleanup() {
   if (fs.existsSync(mapfile)) fs.unlinkSync(mapfile);
+  if (fs.existsSync(deepMapfile)) {
+    fs.unlinkSync(deepMapfile);
+    fs.rmdirSync(fixtures + '/1/2');
+    fs.rmdirSync(fixtures + '/1');
+  }
 }
 
 test('\nwhen piping a bundle generated with browserify through exorcist without adjusting properties', function (t) {
@@ -107,6 +113,33 @@ test('\nwhen piping a bundle generated with browserify thats missing a map throu
       t.ok(missingMapEmitted, 'emits missing-map event')
 
       cb();
-      t.end()
+      t.end();
+      cleanup();
     }
+})
+
+test('\nwhen piping a bundle generated with missing parent folders in map path', function (t) {
+  var data = ''
+  fs.createReadStream(fixtures + '/bundle.js', 'utf8')
+    .pipe(exorcist(deepMapfile))
+    .pipe(through(onread, onflush));
+
+  function onread(d, _, cb) { data += d; cb(); }
+
+  function onflush(cb) {
+    var lines = data.split('\n')
+    t.equal(lines.length, 27, 'pipes entire bundle including prelude, sources and source map url')
+    t.equal(lines.pop(), '//# sourceMappingURL=bundle.js.map', 'last line as source map url pointing to .js.map file')
+
+    var map = JSON.parse(fs.readFileSync(deepMapfile, 'utf8'));
+    t.equal(map.file, 'generated.js', 'leaves file name unchanged')
+    t.equal(map.sources.length, 4, 'maps 4 source files')
+    t.equal(map.sourcesContent.length, 4, 'includes 4 source contents')
+    t.equal(map.mappings.length, 106, 'maintains mappings')
+    t.equal(map.sourceRoot, '', 'leaves source root an empty string')
+
+    cb();
+    t.end();
+    cleanup();
+  }
 })

--- a/test/fixtures/to.css
+++ b/test/fixtures/to.css
@@ -1,0 +1,22 @@
+.note {
+  border-radius: 5px;
+  background: whitesmoke; }
+.note__header {
+  font-size: 2rem; }
+.note__content {
+  font-style: italic; }
+.note--featured {
+  box-shadow: 0 0 10px rgba(255, 0, 0, 0.1); }
+.note--test {
+  border: 1px solid red; }
+
+.task {
+  border-radius: 5px;
+  background: whitesmoke; }
+.task__subject {
+  font-style: italic; }
+.task__status {
+  width: 3rem; }
+.task__status--done {
+  background: greenyellow; }
+/*# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbInNyYy9tYWluL2NvbXBvbmVudHMvbm90ZS9ub3RlLnNjc3MiLCJzcmMvbWFpbi9jb21wb25lbnRzL3Rhc2svdGFzay5zY3NzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUFBO0VBQ0Usb0JBQWU7RUFDZix3QkFBWSxFQUFBO0VBQWQ7SUFHSSxpQkFBVyxFQUFBO0VBQ2Y7SUFHSSxvQkFBWSxFQUFBO0VBQ2hCO0lBR0ksMkNBQVksRUFBQTtFQUNoQjtJQUdJLHVCQUFRLEVBQUE7O0FDakJaO0VBQ0Usb0JBQWU7RUFDZix3QkFBWSxFQUFBO0VBQWQ7SUFHSSxvQkFBWSxFQUFBO0VBQ2hCO0lBR0ksYUFBTyxFQUFBO0lBQVg7TUFHTSx5QkFBWSxFQUFBIiwiZmlsZSI6InRvLmNzcyIsInNvdXJjZXNDb250ZW50IjpbIi5ub3RlIHtcbiAgYm9yZGVyLXJhZGl1czogNXB4O1xuICBiYWNrZ3JvdW5kOiB3aGl0ZXNtb2tlO1xuXG4gICZfX2hlYWRlciB7XG4gICAgZm9udC1zaXplOiAycmVtO1xuICB9XG5cbiAgJl9fY29udGVudCB7XG4gICAgZm9udC1zdHlsZTogaXRhbGljO1xuICB9XG5cbiAgJi0tZmVhdHVyZWQge1xuICAgIGJveC1zaGFkb3c6IDAgMCAxMHB4IHJnYmEoMjU1LCAwLCAwLCAwLjEpO1xuICB9XG5cbiAgJi0tdGVzdCB7XG4gICAgYm9yZGVyOiAxcHggc29saWQgcmVkO1xuICB9XG59XG5cbiIsIi50YXNrIHtcbiAgYm9yZGVyLXJhZGl1czogNXB4O1xuICBiYWNrZ3JvdW5kOiB3aGl0ZXNtb2tlO1xuXG4gICZfX3N1YmplY3Qge1xuICAgIGZvbnQtc3R5bGU6IGl0YWxpYztcbiAgfVxuXG4gICZfX3N0YXR1cyB7XG4gICAgd2lkdGg6IDNyZW07XG5cbiAgICAmLS1kb25lIHtcbiAgICAgIGJhY2tncm91bmQ6IGdyZWVueWVsbG93O1xuICAgIH1cbiAgfVxufVxuXG4iXX0= */

--- a/test/fixtures/to.weirdcss
+++ b/test/fixtures/to.weirdcss
@@ -1,0 +1,22 @@
+.note {
+  border-radius: 5px;
+  background: whitesmoke; }
+.note__header {
+  font-size: 2rem; }
+.note__content {
+  font-style: italic; }
+.note--featured {
+  box-shadow: 0 0 10px rgba(255, 0, 0, 0.1); }
+.note--test {
+  border: 1px solid red; }
+
+.task {
+  border-radius: 5px;
+  background: whitesmoke; }
+.task__subject {
+  font-style: italic; }
+.task__status {
+  width: 3rem; }
+.task__status--done {
+  background: greenyellow; }
+/*# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbInNyYy9tYWluL2NvbXBvbmVudHMvbm90ZS9ub3RlLnNjc3MiLCJzcmMvbWFpbi9jb21wb25lbnRzL3Rhc2svdGFzay5zY3NzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUFBO0VBQ0Usb0JBQWU7RUFDZix3QkFBWSxFQUFBO0VBQWQ7SUFHSSxpQkFBVyxFQUFBO0VBQ2Y7SUFHSSxvQkFBWSxFQUFBO0VBQ2hCO0lBR0ksMkNBQVksRUFBQTtFQUNoQjtJQUdJLHVCQUFRLEVBQUE7O0FDakJaO0VBQ0Usb0JBQWU7RUFDZix3QkFBWSxFQUFBO0VBQWQ7SUFHSSxvQkFBWSxFQUFBO0VBQ2hCO0lBR0ksYUFBTyxFQUFBO0lBQVg7TUFHTSx5QkFBWSxFQUFBIiwiZmlsZSI6InRvLmNzcyIsInNvdXJjZXNDb250ZW50IjpbIi5ub3RlIHtcbiAgYm9yZGVyLXJhZGl1czogNXB4O1xuICBiYWNrZ3JvdW5kOiB3aGl0ZXNtb2tlO1xuXG4gICZfX2hlYWRlciB7XG4gICAgZm9udC1zaXplOiAycmVtO1xuICB9XG5cbiAgJl9fY29udGVudCB7XG4gICAgZm9udC1zdHlsZTogaXRhbGljO1xuICB9XG5cbiAgJi0tZmVhdHVyZWQge1xuICAgIGJveC1zaGFkb3c6IDAgMCAxMHB4IHJnYmEoMjU1LCAwLCAwLCAwLjEpO1xuICB9XG5cbiAgJi0tdGVzdCB7XG4gICAgYm9yZGVyOiAxcHggc29saWQgcmVkO1xuICB9XG59XG5cbiIsIi50YXNrIHtcbiAgYm9yZGVyLXJhZGl1czogNXB4O1xuICBiYWNrZ3JvdW5kOiB3aGl0ZXNtb2tlO1xuXG4gICZfX3N1YmplY3Qge1xuICAgIGZvbnQtc3R5bGU6IGl0YWxpYztcbiAgfVxuXG4gICZfX3N0YXR1cyB7XG4gICAgd2lkdGg6IDNyZW07XG5cbiAgICAmLS1kb25lIHtcbiAgICAgIGJhY2tncm91bmQ6IGdyZWVueWVsbG93O1xuICAgIH1cbiAgfVxufVxuXG4iXX0= */


### PR DESCRIPTION
Hi

Thanks for this project. I really don't like the approach of having two separate builds for dev and prod and the inline source map is giving me a hard time (even if I like the idea in general). Also I love the name of you project :smile: 

This pull requests uses mkdirp for creating non-existing directories in the path specified for the source map. I have this use case in my project and therefore would like to propose this pull request. I've also added a test and refactored the test setup method which I renamed to cleanup which is executed on test finish.

Cheers
Gion