### PR TITLE
Support base-relative sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,21 +37,24 @@ browserify main.js --debug | exorcist bundle.js.map > bundle.js
 ## Usage
 
 ```
-exorcist <mapfile> <exorcist-options>
+exorcist map_file [options]
 
-  Externalizes the source map of a file that is streamed into it by pointing its source map url to the <mapfile>.
-  The original source map is written to the <mapfile> as json.
-  
+  Externalizes the source map of the file streamed in.
+
+  The source map is written as JSON to map_file, and the original file is streamed out with its
+  sourceMappingURL set to the path of map_file (or to the value of the --url option).
+
 OPTIONS:
 
-  --root -r   The path to the original source to be included in the source map.   (default '')
-  --url  -u   The path to the source map to which to point the sourceMappingURL.  (default <mapfile>)
+  --base -b   Base path for calculating relative source paths. (default: use absolute paths)
+  --root -r   Root URL for loading relative source paths. Set as sourceRoot in the source map. (default: '')
+  --url  -u   Full URL to source map. Set as sourceMappingURL in the output stream. (default: map_file)
 
 EXAMPLE:
 
-  Bundle main.js with browserify into bundle.js and externalize the map to bundle.js.map
+  Bundle main.js with browserify into bundle.js and externalize the map to bundle.js.map.
 
-    browserify main.js --debug | exorcist bundle.js.map > bundle.js 
+    browserify main.js --debug | exorcist bundle.js.map > bundle.js
 ```
 
 ## Installation
@@ -74,15 +77,17 @@ EXAMPLE:
 </div>
 <dl>
 <dt>
-<h4 class="name" id="exorcist"><span class="type-signature"></span>exorcist<span class="signature">(file, <span class="optional">url</span>, <span class="optional">root</span>)</span><span class="type-signature"> &rarr; {TransformStream}</span></h4>
+<h4 class="name" id="exorcist"><span class="type-signature"></span>exorcist<span class="signature">(file, <span class="optional">url</span>, <span class="optional">root</span>, <span class="optional">base</span>)</span><span class="type-signature"> &rarr; {TransformStream}</span></h4>
 </dt>
 <dd>
 <div class="description">
-<p>Transforms the incoming stream of code by removing the inlined source map and writing it to an external map file.
-Additionally it adds a source map url that points to the extracted map file.</p>
-<h4>Events (other than all stream events like <code>error</code>)</h4>
+<p>Externalizes the source map of the file streamed in.</p>
+<p>The source map is written as JSON to <code>file</code>, and the original file is streamed out with its
+<code>sourceMappingURL</code> set to the path of <code>file</code> (or to the value of <code>url</code>).</p>
+<h4>Events (in addition to stream events)</h4>
 <ul>
-<li><code>missing-map</code> emitted if no map was found in the stream (the src still is piped through in this case, but no map file is written)</li>
+<li><code>missing-map</code> emitted if no map was found in the stream
+(the src is still piped through in this case, but no map file is written)</li>
 </ul>
 </div>
 <h5>Parameters:</h5>
@@ -113,7 +118,7 @@ Additionally it adds a source map url that points to the extracted map file.</p>
 <td class="attributes">
 &lt;optional><br>
 </td>
-<td class="description last"><p>allows overriding the url at which the map file is found (default: name of map file)</p></td>
+<td class="description last"><p>full URL to the map file, set as <code>sourceMappingURL</code> in the streaming output (default: file)</p></td>
 </tr>
 <tr>
 <td class="name"><code>root</code></td>
@@ -123,7 +128,17 @@ Additionally it adds a source map url that points to the extracted map file.</p>
 <td class="attributes">
 &lt;optional><br>
 </td>
-<td class="description last"><p>allows adjusting the source maps <code>sourceRoot</code> field (default: '')</p></td>
+<td class="description last"><p>root URL for loading relative source paths, set as <code>sourceRoot</code> in the source map (default: '')</p></td>
+</tr>
+<tr>
+<td class="name"><code>base</code></td>
+<td class="type">
+<span class="param-type">String</span>
+</td>
+<td class="attributes">
+&lt;optional><br>
+</td>
+<td class="description last"><p>base path for calculating relative source paths (default: use absolute paths)</p></td>
 </tr>
 </tbody>
 </table>
@@ -133,7 +148,7 @@ Additionally it adds a source map url that points to the extracted map file.</p>
 <li>
 <a href="https://github.com/thlorenz/exorcist/blob/master/index.js">index.js</a>
 <span>, </span>
-<a href="https://github.com/thlorenz/exorcist/blob/master/index.js#L27">lineno 27</a>
+<a href="https://github.com/thlorenz/exorcist/blob/master/index.js#L34">lineno 34</a>
 </li>
 </ul></dd>
 </dl>

--- a/bin/exorcist.js
+++ b/bin/exorcist.js
@@ -17,7 +17,7 @@ function usage() {
 
 var argv = minimist(process.argv.slice(2)
   , { boolean: [ 'h', 'help' ]
-    , string: [ 'url', 'u', 'root', 'r' ]
+    , string: [ 'url', 'u', 'root', 'r', 'base', 'b' ]
   });
 
 if (argv.h || argv.help) return usage();
@@ -30,12 +30,13 @@ if (!mapfile) {
 }
 
 var url  = argv.url  || argv.u
-  , root = argv.root || argv.r;
+  , root = argv.root || argv.r
+  , base = argv.base || argv.b;
 
 mapfile = path.resolve(mapfile);
 
 process.stdin
-  .pipe(exorcist(mapfile, url, root))
+  .pipe(exorcist(mapfile, url, root, base))
   .on('error', console.error.bind(console))
   .on('missing-map', console.error.bind(console))
   .pipe(process.stdout);

--- a/bin/usage.txt
+++ b/bin/usage.txt
@@ -1,15 +1,18 @@
-usage: exorcist <mapfile> <exorcist-options>
+usage: exorcist map_file [options]
 
-  Externalizes the source map of a file that is streamed into it by pointing it's source map url to the <mapfile>.
-  The original source map is written to the <mapfile> as json.
-  
+  Externalizes the source map of the file streamed in.
+
+  The source map is written as JSON to map_file, and the original file is streamed out with its
+  sourceMappingURL set to the path of map_file (or to the value of the --url option).
+
 OPTIONS:
 
-  --root -r   The path to the original source to be included in the source map.   (default '')
-  --url  -u   The path to the source map to which to point the sourceMappingURL.  (default <mapfile>)
+  --base -b   Base path for calculating relative source paths. (default: use absolute paths)
+  --root -r   Root URL for loading relative source paths. Set as sourceRoot in the source map. (default: '')
+  --url  -u   Full URL to source map. Set as sourceMappingURL in the output stream. (default: map_file)
 
 EXAMPLE:
 
-  Bundle main.js with browserify into bundle.js and externalize the map to bundle.js.map
+  Bundle main.js with browserify into bundle.js and externalize the map to bundle.js.map.
 
-    browserify main.js --debug | exorcist bundle.js.map > bundle.js 
+    browserify main.js --debug | exorcist bundle.js.map > bundle.js

--- a/package.json
+++ b/package.json
@@ -15,13 +15,13 @@
   },
   "homepage": "https://github.com/thlorenz/exorcist",
   "dependencies": {
-    "convert-source-map": "~0.3.3",
     "minimist": "0.0.5",
-    "through2": "~0.4.0"
+    "mold-source-map": "~0.3.0"
   },
   "devDependencies": {
     "tap": "~0.4.3",
-    "browserify": "~3.20.0"
+    "browserify": "~3.20.0",
+    "through2": "~0.4.0"
   },
   "keywords": [
     "source-map",


### PR DESCRIPTION
Browserify is overly simple with its handling of source maps: it always passes the full, absolute path of files to transformers, which results in source maps filled with absolute paths.

Exorcist seems like a reasonable place to re-relative-ize the source paths against a consistent base directory. This works in conjunction with `--root` to indicate the URL to use to look up source files.

For example:

```
Input source map contains:
{ ...
  sources: ['/Users/jamesreggio/project/src/foo.js']
  ... }

We execute this:
... | exorcist --base /Users/jamesreggio/project --root http://internal.myapp.com/maps output.js.map > output.js

output.js.map contains:
{ ...
  sourceRoot: 'http://internal.myapp.com/maps',
  sources: ['src/foo.js']
  ... }

In the browser, it will try to resolve the source file at:
http://internal.myapp.com/maps/src/foo.js

...which is correct!
```

I added this feature with documentation and tests. (I also did some housekeeping in the documentation since the `--url` and `--root` options were a little confusing.)

Let me know if you'd like any clarification.