### PR TITLE
Support block comment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,6 @@ lib-cov
 
 pids
 logs
-bundle.*
 
 npm-debug.log
 node_modules

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # exorcist [![build status](https://secure.travis-ci.org/thlorenz/exorcist.png)](http://travis-ci.org/thlorenz/exorcist)
 
-Externalizes the source map found inside a stream to an external `.js.map` file
+Externalizes the source map found inside a stream to an external `.map` file.
+
+Works with both JavaScript and CSS input streams.
 
 ```js
 var browserify = require('browserify')

--- a/index.js
+++ b/index.js
@@ -13,7 +13,17 @@ function separate(src, file, root, base, url) {
   var json = src.toJSON(2);
 
   url = url || path.basename(file);
-  var comment = '//# sourceMappingURL=' + url;
+
+  var comment = '';
+  var commentRx = /^\s*\/(\/|\*)[@#]\s+sourceMappingURL/mg;
+  var commentMatch = commentRx.exec(src.source);
+  var commentBlock = (commentMatch && commentMatch[1] === '*');
+
+  if (commentBlock) {
+    comment = '/*# sourceMappingURL=' + url + ' */';
+  } else {
+    comment = '//# sourceMappingURL=' + url;
+  }
 
   return { json: json, comment: comment }
 }

--- a/test/exorcist.js
+++ b/test/exorcist.js
@@ -7,20 +7,22 @@ var through  = require('through2')
 var exorcist = require('../')
 
 var fixtures = __dirname + '/fixtures';
-var mapfile = fixtures + '/bundle.js.map';
+var scriptMapfile = fixtures + '/bundle.js.map';
+var styleMapfile = fixtures + '/to.css.map';
 
 // This base path is baken into the source maps in the fixtures.
 var base = '/Users/thlorenz/dev/projects/exorcist';
 
-function setup() {
-  if (fs.existsSync(mapfile)) fs.unlinkSync(mapfile);
+function cleanup() {
+  if (fs.existsSync(scriptMapfile)) fs.unlinkSync(scriptMapfile);
+  if (fs.existsSync(styleMapfile)) fs.unlinkSync(styleMapfile);
 }
 
 test('\nwhen piping a bundle generated with browserify through exorcist without adjusting properties', function (t) {
-  setup();
+  t.on('end', cleanup);
   var data = ''
   fs.createReadStream(fixtures + '/bundle.js')
-    .pipe(exorcist(mapfile))
+    .pipe(exorcist(scriptMapfile))
     .pipe(through(onread, onflush));
 
     function onread(d, _, cb) { data += d; cb(); }
@@ -31,7 +33,7 @@ test('\nwhen piping a bundle generated with browserify through exorcist without 
       t.equal(lines.length, 25, 'pipes entire bundle including prelude, sources and source map url')
       t.equal(lines.pop(), '//# sourceMappingURL=bundle.js.map', 'last line as source map url pointing to .js.map file')
 
-      var map = JSON.parse(fs.readFileSync(mapfile, 'utf8'));
+      var map = JSON.parse(fs.readFileSync(scriptMapfile, 'utf8'));
       t.equal(map.file, 'generated.js', 'leaves file name unchanged')
       t.equal(map.sources.length, 4, 'maps 4 source files')
       t.equal(map.sources[0].indexOf(base), 0, 'uses absolute source paths')
@@ -45,10 +47,10 @@ test('\nwhen piping a bundle generated with browserify through exorcist without 
 })
 
 test('\nwhen piping a bundle generated with browserify through exorcist and adjusting url', function (t) {
-  setup();
+  t.on('end', cleanup);
   var data = ''
   fs.createReadStream(fixtures + '/bundle.js')
-    .pipe(exorcist(mapfile, 'http://my.awseome.site/bundle.js.map'))
+    .pipe(exorcist(scriptMapfile, 'http://my.awseome.site/bundle.js.map'))
     .pipe(through(onread, onflush));
 
     function onread(d, _, cb) { data += d; cb(); }
@@ -59,7 +61,7 @@ test('\nwhen piping a bundle generated with browserify through exorcist and adju
       t.equal(lines.length, 25, 'pipes entire bundle including prelude, sources and source map url')
       t.equal(lines.pop(), '//# sourceMappingURL=http://my.awseome.site/bundle.js.map', 'last line as source map url pointing to .js.map file at url set to supplied url')
 
-      var map = JSON.parse(fs.readFileSync(mapfile, 'utf8'));
+      var map = JSON.parse(fs.readFileSync(scriptMapfile, 'utf8'));
       t.equal(map.file, 'generated.js', 'leaves file name unchanged')
       t.equal(map.sources.length, 4, 'maps 4 source files')
       t.equal(map.sourcesContent.length, 4, 'includes 4 source contents')
@@ -72,10 +74,10 @@ test('\nwhen piping a bundle generated with browserify through exorcist and adju
 })
 
 test('\nwhen piping a bundle generated with browserify through exorcist and adjusting root and url', function (t) {
-  setup();
+  t.on('end', cleanup);
   var data = ''
   fs.createReadStream(fixtures + '/bundle.js')
-    .pipe(exorcist(mapfile, 'http://my.awseome.site/bundle.js.map', 'http://my.awesome.site/src'))
+    .pipe(exorcist(scriptMapfile, 'http://my.awseome.site/bundle.js.map', 'http://my.awesome.site/src'))
     .pipe(through(onread, onflush));
 
     function onread(d, _, cb) { data += d; cb(); }
@@ -86,7 +88,7 @@ test('\nwhen piping a bundle generated with browserify through exorcist and adju
       t.equal(lines.length, 25, 'pipes entire bundle including prelude, sources and source map url')
       t.equal(lines.pop(), '//# sourceMappingURL=http://my.awseome.site/bundle.js.map', 'last line as source map url pointing to .js.map file at url set to supplied url')
 
-      var map = JSON.parse(fs.readFileSync(mapfile, 'utf8'));
+      var map = JSON.parse(fs.readFileSync(scriptMapfile, 'utf8'));
       t.equal(map.file, 'generated.js', 'leaves file name unchanged')
       t.equal(map.sources.length, 4, 'maps 4 source files')
       t.equal(map.sourcesContent.length, 4, 'includes 4 source contents')
@@ -99,10 +101,10 @@ test('\nwhen piping a bundle generated with browserify through exorcist and adju
 })
 
 test('\nwhen piping a bundle generated with browserify through exorcist and adjusting root, url, and base', function (t) {
-  setup();
+  t.on('end', cleanup);
   var data = ''
   fs.createReadStream(fixtures + '/bundle.js')
-    .pipe(exorcist(mapfile, 'http://my.awseome.site/bundle.js.map', 'http://my.awesome.site/src', base))
+    .pipe(exorcist(scriptMapfile, 'http://my.awseome.site/bundle.js.map', 'http://my.awesome.site/src', base))
     .pipe(through(onread, onflush));
 
     function onread(d, _, cb) { data += d; cb(); }
@@ -113,7 +115,7 @@ test('\nwhen piping a bundle generated with browserify through exorcist and adju
       t.equal(lines.length, 25, 'pipes entire bundle including prelude, sources and source map url')
       t.equal(lines.pop(), '//# sourceMappingURL=http://my.awseome.site/bundle.js.map', 'last line as source map url pointing to .js.map file at url set to supplied url')
 
-      var map = JSON.parse(fs.readFileSync(mapfile, 'utf8'));
+      var map = JSON.parse(fs.readFileSync(scriptMapfile, 'utf8'));
       t.equal(map.file, 'generated.js', 'leaves file name unchanged')
       t.equal(map.sources.length, 4, 'maps 4 source files')
       t.equal(map.sources[0].indexOf(base), -1, 'uses relative source paths')
@@ -127,11 +129,11 @@ test('\nwhen piping a bundle generated with browserify through exorcist and adju
 })
 
 test('\nwhen piping a bundle generated with browserify thats missing a map through exorcist' , function (t) {
-  setup();
+  t.on('end', cleanup);
   var data = ''
   var missingMapEmitted = false;
   fs.createReadStream(fixtures + '/bundle.nomap.js')
-    .pipe(exorcist(mapfile))
+    .pipe(exorcist(scriptMapfile))
     .on('missing-map', function () { missingMapEmitted = true })
     .pipe(through(onread, onflush));
 
@@ -145,4 +147,30 @@ test('\nwhen piping a bundle generated with browserify thats missing a map throu
       cb();
       t.end()
     }
+})
+
+test('\nwhen performing a stylish exorcism', function (t) {
+  t.on('end', cleanup);
+  var data = ''
+  fs.createReadStream(fixtures + '/to.css')
+    .pipe(exorcist(styleMapfile))
+    .pipe(through(onread, onflush));
+
+  function onread(d, _, cb) { data += d; cb(); }
+
+  function onflush(cb) {
+    var lines = data.split('\n')
+    t.equal(lines.length, 22, 'pipes entire style including prelude, sources and source map url')
+    t.equal(lines.pop(), '/*# sourceMappingURL=to.css.map */', 'last line as source map url pointing to .css.map file')
+
+    var map = JSON.parse(fs.readFileSync(styleMapfile, 'utf8'));
+    t.equal(map.file, 'to.css', 'leaves file name unchanged')
+    t.equal(map.sources.length, 2, 'maps 4 source files')
+    t.equal(map.sourcesContent.length, 2, 'includes 4 source contents')
+    t.equal(map.mappings.length, 214, 'maintains mappings')
+    t.equal(map.sourceRoot, '', 'leaves source root an empty string')
+
+    cb();
+    t.end();
+  }
 })

--- a/test/fixtures/to.css
+++ b/test/fixtures/to.css
@@ -1,0 +1,22 @@
+.note {
+  border-radius: 5px;
+  background: whitesmoke; }
+.note__header {
+  font-size: 2rem; }
+.note__content {
+  font-style: italic; }
+.note--featured {
+  box-shadow: 0 0 10px rgba(255, 0, 0, 0.1); }
+.note--test {
+  border: 1px solid red; }
+
+.task {
+  border-radius: 5px;
+  background: whitesmoke; }
+.task__subject {
+  font-style: italic; }
+.task__status {
+  width: 3rem; }
+.task__status--done {
+  background: greenyellow; }
+/*# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbInNyYy9tYWluL2NvbXBvbmVudHMvbm90ZS9ub3RlLnNjc3MiLCJzcmMvbWFpbi9jb21wb25lbnRzL3Rhc2svdGFzay5zY3NzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUFBO0VBQ0Usb0JBQWU7RUFDZix3QkFBWSxFQUFBO0VBQWQ7SUFHSSxpQkFBVyxFQUFBO0VBQ2Y7SUFHSSxvQkFBWSxFQUFBO0VBQ2hCO0lBR0ksMkNBQVksRUFBQTtFQUNoQjtJQUdJLHVCQUFRLEVBQUE7O0FDakJaO0VBQ0Usb0JBQWU7RUFDZix3QkFBWSxFQUFBO0VBQWQ7SUFHSSxvQkFBWSxFQUFBO0VBQ2hCO0lBR0ksYUFBTyxFQUFBO0lBQVg7TUFHTSx5QkFBWSxFQUFBIiwiZmlsZSI6InRvLmNzcyIsInNvdXJjZXNDb250ZW50IjpbIi5ub3RlIHtcbiAgYm9yZGVyLXJhZGl1czogNXB4O1xuICBiYWNrZ3JvdW5kOiB3aGl0ZXNtb2tlO1xuXG4gICZfX2hlYWRlciB7XG4gICAgZm9udC1zaXplOiAycmVtO1xuICB9XG5cbiAgJl9fY29udGVudCB7XG4gICAgZm9udC1zdHlsZTogaXRhbGljO1xuICB9XG5cbiAgJi0tZmVhdHVyZWQge1xuICAgIGJveC1zaGFkb3c6IDAgMCAxMHB4IHJnYmEoMjU1LCAwLCAwLCAwLjEpO1xuICB9XG5cbiAgJi0tdGVzdCB7XG4gICAgYm9yZGVyOiAxcHggc29saWQgcmVkO1xuICB9XG59XG5cbiIsIi50YXNrIHtcbiAgYm9yZGVyLXJhZGl1czogNXB4O1xuICBiYWNrZ3JvdW5kOiB3aGl0ZXNtb2tlO1xuXG4gICZfX3N1YmplY3Qge1xuICAgIGZvbnQtc3R5bGU6IGl0YWxpYztcbiAgfVxuXG4gICZfX3N0YXR1cyB7XG4gICAgd2lkdGg6IDNyZW07XG5cbiAgICAmLS1kb25lIHtcbiAgICAgIGJhY2tncm91bmQ6IGdyZWVueWVsbG93O1xuICAgIH1cbiAgfVxufVxuXG4iXX0= */


### PR DESCRIPTION
This PR supersedes #8, which has been dormant for quite some time.

Instead of requiring a `--block` argument or looking at the file type, we merely check the type of comment already present in the stream and use that to insert the new, relative `sourceMappingURL`.

(This PR expects #12 to be merged first.)