### PR TITLE
Improve error response

### DIFF
--- a/bin/exorcist.js
+++ b/bin/exorcist.js
@@ -7,6 +7,11 @@ var minimist = require('minimist')
   , exorcist = require('../')
   ;
 
+function onerror(err) {
+  console.error(err.toString());
+  process.exit(err.errno || 1);
+}
+
 function usage() {
   var usageFile = path.join(__dirname, 'usage.txt');
   fs.createReadStream(usageFile).pipe(process.stdout);
@@ -37,7 +42,7 @@ mapfile = path.resolve(mapfile);
 
 process.stdin
   .pipe(exorcist(mapfile, url, root, base))
-  .on('error', console.error.bind(console))
+  .on('error', onerror)
   .on('missing-map', console.error.bind(console))
   .pipe(process.stdout);
 

--- a/index.js
+++ b/index.js
@@ -62,7 +62,8 @@ function exorcist(file, url, root, base) {
     }
 
     var separated = separate(src, file, root, base, url);
-    fs.writeFile(file, separated.json, 'utf8', function() {
+    fs.writeFile(file, separated.json, 'utf8', function(err) {
+      if (err) return stream.emit('error', err);
       write(separated.comment);
     });
   });

--- a/test/exorcist.js
+++ b/test/exorcist.js
@@ -128,6 +128,19 @@ test('\nwhen piping a bundle generated with browserify through exorcist and adju
     }
 })
 
+test('\nwhen piping a bundle generated with browserify to a map file in a directory that does not exist', function (t) {
+  t.on('end', cleanup);
+  var badPathScriptMapfile = fixtures + '/noexists/bundle.js.map';
+  fs.createReadStream(fixtures + '/bundle.js')
+    .pipe(exorcist(badPathScriptMapfile))
+    .on('error', onerror);
+
+  function onerror(err) {
+    t.type(err, 'Error');
+    t.end();
+  }
+})
+
 test('\nwhen piping a bundle generated with browserify thats missing a map through exorcist' , function (t) {
   t.on('end', cleanup);
   var data = ''


### PR DESCRIPTION
- Emit fs.writeFile errors (previously swallowed)
- Return non-zero exit code on error (previously only displayed message)
- Resolves https://github.com/thlorenz/exorcist/issues/18

Note: Similar functionality is bundled into other open PRs. I realize you're ultra busy so I'm hoping a smaller, focused PR increases odds of merge :D

If this gets accepted, I'd like to submit a follow-up PR for emitting an error on empty stream.

Thanks <3