### PR TITLE
Add --error-on-missing option

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,19 @@ exorcist map_file [options]
 
 OPTIONS:
 
-  --base -b   Base path for calculating relative source paths. (default: use absolute paths)
-  --root -r   Root URL for loading relative source paths. Set as sourceRoot in the source map. (default: '')
-  --url  -u   Full URL to source map. Set as sourceMappingURL in the output stream. (default: map_file)
+              --base -b   Base path for calculating relative source paths.
+                          (default: use absolute paths)
+
+              --root -r   Root URL for loading relative source paths.
+                          Set as sourceRoot in the source map.
+                          (default: '')
+
+               --url -u   Full URL to source map.
+                          Set as sourceMappingURL in the output stream.
+                          (default: map_file)
+
+  --error-on-missing -e   Abort with error if no map is found in the stream.
+                          (default: warn but still pipe through source)
 
 EXAMPLE:
 
@@ -79,7 +89,7 @@ EXAMPLE:
 </div>
 <dl>
 <dt>
-<h4 class="name" id="exorcist"><span class="type-signature"></span>exorcist<span class="signature">(file, <span class="optional">url</span>, <span class="optional">root</span>, <span class="optional">base</span>)</span><span class="type-signature"> &rarr; {TransformStream}</span></h4>
+<h4 class="name" id="exorcist"><span class="type-signature"></span>exorcist<span class="signature">(file, <span class="optional">url</span>, <span class="optional">root</span>, <span class="optional">base</span>, <span class="optional">errorOnMissing</span>)</span><span class="type-signature"> &rarr; {TransformStream}</span></h4>
 </dt>
 <dd>
 <div class="description">
@@ -88,7 +98,7 @@ EXAMPLE:
 <code>sourceMappingURL</code> set to the path of <code>file</code> (or to the value of <code>url</code>).</p>
 <h4>Events (in addition to stream events)</h4>
 <ul>
-<li><code>missing-map</code> emitted if no map was found in the stream
+<li><code>missing-map</code> emitted if no map was found in the stream and errorOnMissing is falsey
 (the src is still piped through in this case, but no map file is written)</li>
 </ul>
 </div>
@@ -142,6 +152,16 @@ EXAMPLE:
 </td>
 <td class="description last"><p>base path for calculating relative source paths (default: use absolute paths)</p></td>
 </tr>
+<tr>
+<td class="name"><code>errorOnMissing</code></td>
+<td class="type">
+<span class="param-type">Boolean</span>
+</td>
+<td class="attributes">
+&lt;optional><br>
+</td>
+<td class="description last"><p>when truthy, causes 'error' to be emitted instead of 'missing-map' if no map was found in the stream (default: falsey)</p></td>
+</tr>
 </tbody>
 </table>
 <dl class="details">
@@ -150,7 +170,7 @@ EXAMPLE:
 <li>
 <a href="https://github.com/thlorenz/exorcist/blob/master/index.js">index.js</a>
 <span>, </span>
-<a href="https://github.com/thlorenz/exorcist/blob/master/index.js#L34">lineno 34</a>
+<a href="https://github.com/thlorenz/exorcist/blob/master/index.js#L33">lineno 33</a>
 </li>
 </ul></dd>
 </dl>

--- a/bin/exorcist.js
+++ b/bin/exorcist.js
@@ -21,7 +21,7 @@ function usage() {
 (function damnYouEsprima() {
 
 var argv = minimist(process.argv.slice(2)
-  , { boolean: [ 'h', 'help' ]
+  , { boolean: [ 'h', 'help', 'e', 'error-on-missing' ]
     , string: [ 'url', 'u', 'root', 'r', 'base', 'b' ]
   });
 
@@ -34,14 +34,15 @@ if (!mapfile) {
   return usage();
 }
 
-var url  = argv.url  || argv.u
-  , root = argv.root || argv.r
-  , base = argv.base || argv.b;
+var url            = argv.url            || argv.u
+  , root           = argv.root           || argv.r
+  , base           = argv.base           || argv.b
+  , errorOnMissing = argv.errorOnMissing || argv.e;
 
 mapfile = path.resolve(mapfile);
 
 process.stdin
-  .pipe(exorcist(mapfile, url, root, base))
+  .pipe(exorcist(mapfile, url, root, base, errorOnMissing))
   .on('error', onerror)
   .on('missing-map', console.error.bind(console))
   .pipe(process.stdout);

--- a/bin/usage.txt
+++ b/bin/usage.txt
@@ -7,9 +7,19 @@ usage: exorcist map_file [options]
 
 OPTIONS:
 
-  --base -b   Base path for calculating relative source paths. (default: use absolute paths)
-  --root -r   Root URL for loading relative source paths. Set as sourceRoot in the source map. (default: '')
-  --url  -u   Full URL to source map. Set as sourceMappingURL in the output stream. (default: map_file)
+              --base -b   Base path for calculating relative source paths.
+                          (default: use absolute paths)
+
+              --root -r   Root URL for loading relative source paths.
+                          Set as sourceRoot in the source map.
+                          (default: '')
+
+               --url -u   Full URL to source map.
+                          Set as sourceMappingURL in the output stream.
+                          (default: map_file)
+
+  --error-on-missing -e   Abort with error if no map is found in the stream.
+                          (default: warn but still pipe through source)
 
 EXAMPLE:
 

--- a/test/exorcist.js
+++ b/test/exorcist.js
@@ -136,12 +136,25 @@ test('\nwhen piping a bundle generated with browserify to a map file in a direct
     .on('error', onerror);
 
   function onerror(err) {
-    t.type(err, 'Error');
+    t.type(err, 'Error', 'emits an Error');
     t.end();
   }
 })
 
-test('\nwhen piping a bundle generated with browserify thats missing a map through exorcist' , function (t) {
+test('\nwhen piping a bundle generated with browserify thats missing a map through exorcist and errorOnMissing is truthy' , function (t) {
+  t.on('end', cleanup);
+  var data = ''
+  fs.createReadStream(fixtures + '/bundle.nomap.js')
+    .pipe(exorcist(scriptMapfile, undefined, undefined, undefined, true))
+    .on('error', onerror);
+
+  function onerror(err) {
+    t.type(err, 'Error', 'emits an Error');
+    t.end();
+  }
+})
+
+test('\nwhen piping a bundle generated with browserify thats missing a map through exorcist and errorOnMissing is falsey' , function (t) {
   t.on('end', cleanup);
   var data = ''
   var missingMapEmitted = false;


### PR DESCRIPTION
@abritinthebay @thlorenz @jacwright Here's what I had in mind to give users the ability to treat a lack of a source map in the stream as an error, without introducing any breaking changes for those who depend on the currently functionality. Look forward to review! Thanks :D

- Resolves #31 
- When the `--error-on-missing` option is provided via the CLI, and no source map is found in the stream, it'll `process.exit` with an exit code of 1 instead of merely outputting a warning message and continuing.
- When the `errorOnMissing` argument is truthy via the API, it'll emit `error` instead of `missing-map`.
- Documentation updated stylistically due to issues caused by `--error-on-missing` being much longer than existing options.