### PR TITLE
travis -> github actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,18 @@
+name: Test
+on: [push, pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [14.x]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v2
+      with:
+        node-version: ${{ matrix.node-version }}
+    - name: install and test
+      run: |
+        npm install
+        npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,0 @@
-language: node_js
-node_js:
-  - "0.10"
-  - "0.12"
-  - "iojs"


### PR DESCRIPTION
Replaces Travis with GitHub Actions. Travis's OSS tier is barely usable at this point.