### PR TITLE
deps: update devDeps, use ^

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
   "devDependencies": {
     "browserify": "^17.0.0",
     "nave": "^3.2.2",
-    "proxyquire": "~2.1.3",
-    "tap": "~14.11.0",
+    "proxyquire": "^2.1.3",
+    "tap": "^14.11.0",
     "through2": "~4.0.2"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -43,6 +43,6 @@
   },
   "license": "MIT",
   "engine": {
-    "node": ">=0.6"
+    "node": ">=14"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,12 +7,7 @@
   },
   "main": "index.js",
   "scripts": {
-    "test-main": "tap test/*.js",
-    "test-0.10": " nave use 0.10 npm run test-main",
-    "test-0.12": " nave use 0.12 npm run test-main",
-    "test-iojs": " nave use latest npm run test-main",
-    "test-all": "npm run test-main && npm run test-0.10 && npm run test-0.12 && npm run test-iojs",
-    "test": "if [ -e $TRAVIS ]; then npm run test-all; else npm run test-main; fi"
+    "test": "tap test/*.js"
   },
   "repository": {
     "type": "git",
@@ -28,9 +23,9 @@
   "devDependencies": {
     "browserify": "^17.0.0",
     "nave": "^3.2.2",
-    "proxyquire": "^2.1.3",
-    "tap": "^14.11.0",
-    "through2": "^4.0.2"
+    "proxyquire": "~2.1.3",
+    "tap": "~14.11.0",
+    "through2": "~4.0.2"
   },
   "keywords": [
     "source-map",

--- a/package.json
+++ b/package.json
@@ -26,11 +26,11 @@
     "mold-source-map": "~0.4.0"
   },
   "devDependencies": {
-    "browserify": "~10.2.0",
-    "nave": "~0.5.1",
-    "proxyquire": "~1.7.9",
-    "tap": "~0.4.3",
-    "through2": "~0.4.0"
+    "browserify": "^17.0.0",
+    "nave": "^3.2.2",
+    "proxyquire": "^2.1.3",
+    "tap": "^14.11.0",
+    "through2": "^4.0.2"
   },
   "keywords": [
     "source-map",


### PR DESCRIPTION
Updates all devDependencies and removes old multi-version test helpers. Tests are now compatible with Node 14+. 