### PR TITLE
get tests passing on Node.js 16.x

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [14.x, 16.x]
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ logs
 
 npm-debug.log
 node_modules
+
+.nyc_output/

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "browserify": "^17.0.0",
     "nave": "^3.2.2",
     "proxyquire": "^2.1.3",
-    "tap": "^14.11.0",
+    "tap": "^15.1.6",
     "through2": "~4.0.2"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -44,5 +44,11 @@
   "license": "MIT",
   "engine": {
     "node": ">=14"
+  },
+  "tap": {
+    "branches": 95,
+    "lines": 95,
+    "functions": 100,
+    "statements": 95
   }
 }


### PR DESCRIPTION
hi there! 👋 upgrading tap is all that was needed to get tests passing in the current LTS version of Node.js.

---

### disclaimer (1)
16.x displays a deprecation warning related to a dependency. in order to resolve the nag @bendrucker (or some other kind soul) would need to merge [this old chestnut](https://github.com/thlorenz/mold-source-map/pull/13) too...

```
> exorcist@2.0.0 test
> tap test/*.js

test/exorcist.js 2> (node:86531) [DEP0128] DeprecationWarning: Invalid 'main' field in '/Users/john/code/exorcist/node_modules/mold-source-map/package.json' of
'mold-source-map.js'. Please either fix that or report it to the module author
 ```
 
### disclaimer (2)
`tap@15` turns on coverage by default. if it'd be preferable to leave it off or ignore the sole conditional block without a corresponding test, just say the word.

